### PR TITLE
Session Expired View

### DIFF
--- a/Example/SplitScreenScanner/StartScanningViewController.swift
+++ b/Example/SplitScreenScanner/StartScanningViewController.swift
@@ -55,6 +55,14 @@ extension StartScanningViewController: SplitScannerCoordinatorDelegate {
         return "Please scan my barcode"
     }
 
+    func scanToContinueTitle(_ SplitScannerCoordinator: SplitScannerCoordinator) -> String {
+        return "Continue?"
+    }
+
+    func scanToContinueDescription(_ SplitScannerCoordinator: SplitScannerCoordinator) -> String? {
+        return "Scan barcode #SO0000000001195"
+    }
+
     func wrongStartingBarcodeScannedMessage(_ SplitScannerCoordinator: SplitScannerCoordinator) -> String {
         return "Wrong Barcode Scanned"
     }

--- a/SplitScreenScanner/Classes/BarcodeScannerViewModel.swift
+++ b/SplitScreenScanner/Classes/BarcodeScannerViewModel.swift
@@ -38,4 +38,8 @@ extension BarcodeScannerViewModel: ContinuousBarcodeScannerDelegate {
     func didScan(barcode: String) {
         delegate?.didScanBarcode(self, barcode: barcode)
     }
+
+    func resetLastScannedBarcode() {
+        barcodeScanner.resetLastScannedBarcode()
+    }
 }

--- a/SplitScreenScanner/Classes/ContinuousBarcodeScanner.swift
+++ b/SplitScreenScanner/Classes/ContinuousBarcodeScanner.swift
@@ -125,4 +125,8 @@ extension ContinuousBarcodeScanner {
         captureSession.stopRunning()
         previewLayer.removeFromSuperlayer()
     }
+
+    func resetLastScannedBarcode() {
+        metadataCapture.lastBarcodeScanned = nil
+    }
 }

--- a/SplitScreenScanner/Classes/ScanHistoryTableViewController.swift
+++ b/SplitScreenScanner/Classes/ScanHistoryTableViewController.swift
@@ -36,6 +36,20 @@ class ScanHistoryTableViewController: UITableViewController {
         tableView.separatorInset = .zero
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        viewModel.createExpireSessionTimer()
+    }
+
+    override func willMove(toParentViewController parent: UIViewController?) {
+        super.willMove(toParentViewController: parent)
+
+        if parent == nil {
+            viewModel.invalidateExpireSessionTimer()
+        }
+    }
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         return viewModel.sections.count
     }

--- a/SplitScreenScanner/Classes/SplitScannerViewModel.swift
+++ b/SplitScreenScanner/Classes/SplitScannerViewModel.swift
@@ -18,8 +18,20 @@ class SplitScannerViewModel {
 
     weak var delegate: SplitScannerViewModelDelegate?
 
+    enum ScannerState {
+        case notStarted
+        case started
+        case expired
+    }
+    var scannerState: ScannerState
+
+    var scannerIsExpired: Bool {
+        return scannerState == .expired
+    }
+
     init(deviceProvider: DeviceProviding) {
         self.deviceProvider = deviceProvider
+        self.scannerState = .notStarted
     }
 
     // MARK: - Bindings, Observers, Getters


### PR DESCRIPTION
## Pivotal Tickets
https://www.pivotaltracker.com/story/show/156513370
https://www.pivotaltracker.com/story/show/156511919

## Feature Images
Now when you start a scanning session, the session will expire after 30 seconds without a scan. This means that you will have to rescan the starting barcode in order to continue your session.
![img_0059 2](https://user-images.githubusercontent.com/10718632/38830227-70275b30-4170-11e8-96ab-e7e59107de5e.PNG)

## What To Test?
- Open a scanning session and scan the starting barcode. 
- Don't make a scan for the next 30 seconds and make sure the scanning sessions expires.
- Rescan the truck barcode and make sure the scanning session is unlocked once again.
- Scan a few barcodes and make sure the history table updates as normal.
- Wait another 30 seconds after your last scan and make sure the session expires.