### PR TITLE
Fixed History Cell Animation

### DIFF
--- a/SplitScreenScanner/Classes/ScanHistoryTableViewController.swift
+++ b/SplitScreenScanner/Classes/ScanHistoryTableViewController.swift
@@ -15,7 +15,7 @@ class ScanHistoryTableViewController: UITableViewController {
 
         viewModel.reloadRowBinding = { [weak self] indexPath in
             DispatchQueue.main.async {
-                self?.tableView.reloadRows(at: [indexPath], with: .left)
+                self?.tableView.reloadRows(at: [indexPath], with: .right)
             }
         }
 


### PR DESCRIPTION
## Feature Description
Fixed an issue that would cause the first scan's history cell to animate in from the wrong direction.

## What to Test?
- Unlock the scanning session by scanning the starting barcode.
- Once you scan your first barcode make now of which way the history cell animated in from.
- Scan another barcode and make sure that history cell animates in from the same direction.