### PR TITLE
Expire Scanning Session When app Enters Background

### DIFF
--- a/SplitScreenScanner/Classes/ScanHistoryTableViewController.swift
+++ b/SplitScreenScanner/Classes/ScanHistoryTableViewController.swift
@@ -40,6 +40,7 @@ class ScanHistoryTableViewController: UITableViewController {
         super.viewWillAppear(animated)
 
         viewModel.createExpireSessionTimer()
+        NotificationCenter.default.addObserver(self, selector: #selector(expire), name: .UIApplicationDidEnterBackground, object: nil)
     }
 
     override func willMove(toParentViewController parent: UIViewController?) {
@@ -48,6 +49,12 @@ class ScanHistoryTableViewController: UITableViewController {
         if parent == nil {
             viewModel.invalidateExpireSessionTimer()
         }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -90,5 +97,12 @@ class ScanHistoryTableViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 80
+    }
+}
+
+private extension ScanHistoryTableViewController {
+    @objc func expire() {
+        viewModel.invalidateExpireSessionTimer()
+        viewModel.expireScanningSession()
     }
 }


### PR DESCRIPTION
## Pivotal Ticket
https://www.pivotaltracker.com/story/show/156865952

## Feature Description
Now when the app enters the background during a scanning session, the scanning session will expire.

## What To Test?
- Open the app and scan the starting barcode to enter a scanning session
- Test locking the phone and make sure the scanning session is expired
- Test returning to the home screen and tapping back into the app (the scanning session should be expired)