### PR TITLE
Load Barcode Scanner After View Appears

### DIFF
--- a/SplitScreenScanner/Assets/SplitScanner.storyboard
+++ b/SplitScreenScanner/Assets/SplitScanner.storyboard
@@ -23,7 +23,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KIK-1o-Irv">
                                 <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleAspectFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="4T8-tK-tow">
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="4T8-tK-tow">
                                         <rect key="frame" x="16" y="5" width="343" height="34"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scanner Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rar-8r-fDF">
@@ -104,7 +104,7 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" red="0.12941176470588234" green="0.16078431372549018" blue="0.15686274509803921" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="QNI-Us-qvf" firstAttribute="centerY" secondItem="kLo-EH-hPe" secondAttribute="centerY" id="SaY-2p-rpa"/>
                             <constraint firstItem="QNI-Us-qvf" firstAttribute="centerX" secondItem="kLo-EH-hPe" secondAttribute="centerX" id="lrK-KK-Eot"/>

--- a/SplitScreenScanner/Classes/BarcodeScannerViewController.swift
+++ b/SplitScreenScanner/Classes/BarcodeScannerViewController.swift
@@ -11,14 +11,14 @@ import AVFoundation
 class BarcodeScannerViewController: UIViewController {
     var viewModel: BarcodeScannerViewModel!
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
         viewModel.startRunningBarcodeScanner()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
 
         viewModel.stopRunningBarcodeScanner()
     }


### PR DESCRIPTION
## Pivotal Tickets
https://www.pivotaltracker.com/story/show/157166935

## Feature Images
Reduced popover lag by starting the barcode scanner after the view has appeared.
![img_0090 2](https://user-images.githubusercontent.com/10718632/39545621-a156399a-4e06-11e8-8c9c-96962304b299.PNG)

![img_0091 2](https://user-images.githubusercontent.com/10718632/39545623-a50cadf8-4e06-11e8-8663-2cf137237502.PNG)

## What To Test?
- Open the barcode scanner and maker sure it pops up instantly with an unstarted barcode scanner.
- After a couple of seconds, make sure the barcode scanner starts and functions as normal.
- Dismiss the barcode scanner, making sure that works as expected as well.