### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Pivotal Tickets
+_(insert all relevant Pivotal tickets here)_
+
+## Feature Description
+_(please provide a description of the feature as well as a few screenshots, when needed, displaying the changes that have been made)_
+
+## What To Test?
+_(please provide all relevant test cases needed to fully test this feature)_


### PR DESCRIPTION
Added a pull request template. This is just a copy pasta of the one in Clutter WMS with a few slight changes. This template will need to be fixed up quite a bit if we ever want to make this pod open source, but as of now this will work quite well for internal needs.