### PR TITLE
Manually block scanner, instead of using delegate result

### DIFF
--- a/Example/SplitScreenScanner/StartScanningViewController.swift
+++ b/Example/SplitScreenScanner/StartScanningViewController.swift
@@ -31,15 +31,15 @@ class StartScanningViewController: UIViewController {
 
 // MARK: - SplitScannerCoordinatorDelegate
 extension StartScanningViewController: SplitScannerCoordinatorDelegate {
-    func didScanBarcode(_ splitScannerCoordinator: SplitScannerCoordinator, barcode: String) -> (result: ScanResult, blocking: Bool) {
+    func didScanBarcode(_ splitScannerCoordinator: SplitScannerCoordinator, barcode: String) -> ScanResult {
         print("Scanned: " + barcode)
         switch Int(arc4random_uniform(4)) {
         case 0...1:
-            return (result: .success(description: "Nice scan!"), blocking: false)
+            return .success(description: "Nice scan!")
         case 2:
-            return (result: .warning(description: "Poor scan!"), blocking: false)
+            return .warning(description: "Poor scan!")
         default:
-            return (result: .error(description: "Bogus scan!"), blocking: false)
+            return .error(description: "Bogus scan!")
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -43,18 +43,15 @@ extension StartScanningViewController: SplitScannerCoordinatorDelegate {
     // .success -> green checkmark image
     // .warning -> yellow exclamation triangle
     // .error -> red exclamation triangle
-    // The "blocking" value that is returned by this function decides if this scan should block the scanner.
-    // When the scanner is blocked, a grey background and smaller white overlay with the last scanned barcode's value inside will be displayed in place of the scanner.
-    // To unblock the scanner, call splitScannerCoordinator.unblockScanner()
-    func didScanBarcode(_ splitScannerCoordinator: SplitScannerCoordinator, barcode: String) -> (result: ScanResult, blocking: Bool) {
+    func didScanBarcode(_ splitScannerCoordinator: SplitScannerCoordinator, barcode: String) -> ScanResult {
         print("Scanned: " + barcode)
         switch Int(arc4random_uniform(4)) {
         case 0...1:
-            return (result: .success(description: "Nice scan!"), blocking: false)
+            return .success(description: "Nice scan!")
         case 2:
-            return (result: .warning(description: "Poor scan!"), blocking: false)
+            return .warning(description: "Poor scan!")
         default:
-            return (result: .error(description: "Bogus scan!"), blocking: false)
+            return .error(description: "Bogus scan!")
         }
     }
 
@@ -142,7 +139,7 @@ splitScannerCoordinator = try SplitScannerCoordinator(navigation: navigation, sc
 <img src="Screenshots/scan_history_no_scans.png" height="50%" width="50%">
 (Empty scan history view)
 
-If a scan has blocking set to true, then the scanner will be blocked and remain blocked until `splitScannerCoordinator.unblockScanner()` is called.
+To temporarily disable the scanner, call `splitScannerCoordinator.blockScanner(withMessage: barcode)`. While the scanner is disabled, it will display the message passed to `blockScanner(withMessage:)` (in this case, `barcode`) instead of the camera. To re-enable the scanner, call `splitScannerCoordinator.unblockScanner()`.
 
 <img src="Screenshots/blocked_scanner.png" height="50%" width="50%">
 (Blocked scanner view)

--- a/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
+++ b/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
@@ -9,7 +9,7 @@ import UIKit
 import AVFoundation
 
 public protocol SplitScannerCoordinatorDelegate: class {
-    func didScanBarcode(_ splitScannerCoordinator: SplitScannerCoordinator, barcode: String) -> (result: ScanResult, blocking: Bool)
+    func didScanBarcode(_ splitScannerCoordinator: SplitScannerCoordinator, barcode: String) -> ScanResult
     func didPressDoneButton(_ splitScannerCoordinator: SplitScannerCoordinator)
 }
 
@@ -90,6 +90,10 @@ public class SplitScannerCoordinator: RootCoordinator, Coordinator {
 
 // MARK: - Public Methods
 extension SplitScannerCoordinator {
+    public func blockScanner(withMessage message: String) {
+        barcodeScannerViewModel?.blockScanner(withMessage: message)
+    }
+
     public func unblockScanner() {
         barcodeScannerViewModel?.unblockScanner()
     }
@@ -175,12 +179,8 @@ extension SplitScannerCoordinator: SplitScannerViewModelDelegate {
 extension SplitScannerCoordinator: BarcodeScannerViewModelDelegate {
     func didScanBarcode(_ barcodeScannerViewModel: BarcodeScannerViewModel, barcode: String) {
         if currentlyDisplayedInfoVC is ScanHistoryTableViewController {
-            guard let (scanResult, blocking) = delegate?.didScanBarcode(self, barcode: barcode) else { return }
+            guard let scanResult = delegate?.didScanBarcode(self, barcode: barcode) else { return }
             scanHistoryViewModel?.didScan(barcode: barcode, with: scanResult)
-
-            if blocking {
-                barcodeScannerViewModel.blockScanner(withMessage: barcode)
-            }
         } else {
             scanToContinueViewModel?.didScan(barcode: barcode)
         }


### PR DESCRIPTION
`SplitScannerCoordinatorDelegate.didScanBarcode` once again returns just a `ScanResult`, instead of `(result: ScanResult, blocking: Bool)`. To block the scanner, call `splitScannerCoordinator.blockScanner(withMessage: barcode)`.

This allows the elimination of a race condition when unblocking the scanner at the completion of an asynchronous request. If the asynchronous request finished and attempted to unblock the scanner before the scanner blocked itself, the scanner would remain blocked indefinitely.

## Pivotal Tickets
Noticed during review of [In progress view for put-away tasks list](https://www.pivotaltracker.com/story/show/158646790)