### PR TITLE
Expose resetLastScannedBarcode as a public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ If a scan has blocking set to true, then the scanner will be blocked and remain 
 <img src="Screenshots/blocked_scanner.png" height="50%" width="50%">
 (Blocked scanner view)
 
+To avoid duplicate scans, the scanner will not scan the same barcode twice in a row. If you want to allow your users to undo the last scan, or want to allow rescanning the last barcode for any other reason, call `splitScannerCoordinator.resetLastScannedBarcode()`.
+
 ## Requirements
 
 - iOS 11.0+

--- a/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
+++ b/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
@@ -93,6 +93,10 @@ extension SplitScannerCoordinator {
     public func unblockScanner() {
         barcodeScannerViewModel?.unblockScanner()
     }
+
+    public func resetLastScannedBarcode() {
+        barcodeScannerViewModel?.resetLastScannedBarcode()
+    }
 }
 
 // MARK: - Private Methods


### PR DESCRIPTION
`SplitScannerCoordinator` now exposes `resetLastScannedBarcode()` as a public method, allowing library users to undo the last scan or enable rescanning the last barcode for any other reason.

## Pivotal Tickets
[Allow users to scan same barcode after hitting the undo button](https://www.pivotaltracker.com/story/show/158875627)