### PR TITLE
Increase scanner timeout; remove guaranteed length

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ extension StartScanningViewController: ScanToContinueDataSource {
 }
 ```
 
-Please note that when initializing splitScannerCoordinator the `scanToContinueDataSource: ScanToContinueDataSource?` parameter is optional. Only populate this parameter with a value if you want your scanning session to require an initial scan, using the `scan(startingBarcode:)` method, to start the main barcode scanner (e.g. need to scan truck before scanning items) and if you want your scanning session to be expirable. Being expirable means that your scanning session will expire after 30 seconds without a scan, or when the app is backgrounded. If a scanning session expires then it will need to be started again. This means the scanner will now be calling the `scan(startingBarcode:)` method again until it receives a .success ScanResult.
+Please note that when initializing splitScannerCoordinator the `scanToContinueDataSource: ScanToContinueDataSource?` parameter is optional. Only populate this parameter with a value if you want your scanning session to require an initial scan, using the `scan(startingBarcode:)` method, to start the main barcode scanner (e.g. need to scan truck before scanning items) and if you want your scanning session to be expirable. Being expirable means that your scanning session will expire after a short period of time without a scan, or when the app is backgrounded. If a scanning session expires then it will need to be started again. This means the scanner will now be calling the `scan(startingBarcode:)` method again until it receives a .success ScanResult.
 
 <img src="Screenshots/scan_to_begin.png" height="50%" width="50%">
 (Scan to begin view)

--- a/SplitScreenScanner/Classes/ScanHistoryViewModel.swift
+++ b/SplitScreenScanner/Classes/ScanHistoryViewModel.swift
@@ -86,7 +86,7 @@ extension ScanHistoryViewModel {
     func createExpireSessionTimer() {
         guard isScanningSessionExpirable else { return }
 
-        expireSessionTimer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: false, block: { [weak self] _ in
+        expireSessionTimer = Timer.scheduledTimer(withTimeInterval: 45.0, repeats: false, block: { [weak self] _ in
             self?.expireScanningSession()
         })
     }


### PR DESCRIPTION
- Increases the scan-to-continue timeout from 30 seconds to 45 seconds
- Removes the readme’s guarantee that the timeout is 30 seconds (“after 30 seconds without a scan” → “after a short period of time without a scan”)

## Pivotal Tickets
[Update the scan-to-truck scanner timeout to 45 seconds](https://www.pivotaltracker.com/story/show/158892076)