### PR TITLE
Bump SplitScreenScanner to 7.0.0 - Adds new `pending` case to `ScanResult`

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Sections (0.8.0)
-  - SplitScreenScanner (6.1.0):
+  - SplitScreenScanner (7.0.0):
     - Sections
   - SwiftLint (0.28.0)
 
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Sections: efc268a207d0e7afba82d2a0efd6cdf61872b5d4
-  SplitScreenScanner: 16d90509c923950306ce2e8079dddfdcc720fd30
+  SplitScreenScanner: d033d2f8ff4d0c8289efd2e6e96f79217bc91a93
   SwiftLint: 088cfacb75b45970017e62b7524d506776d60148
 
 PODFILE CHECKSUM: 662fda703b72b77c2ece8658c02a5b890176b006

--- a/Example/SplitScreenScanner.xcodeproj/project.pbxproj
+++ b/Example/SplitScreenScanner.xcodeproj/project.pbxproj
@@ -130,8 +130,8 @@
 			children = (
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 				C926E5B120783CAD00903887 /* ScanHistoryViewModelTests.swift */,
-				C9928C03207550F9001B36DD /* SplitScannerViewModelTests.swift */,
 				C95DD8E0207ED14A0069C5C0 /* ScanToContinueViewModelTests.swift */,
+				C9928C03207550F9001B36DD /* SplitScannerViewModelTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";

--- a/Example/SplitScreenScanner.xcodeproj/project.pbxproj
+++ b/Example/SplitScreenScanner.xcodeproj/project.pbxproj
@@ -176,8 +176,8 @@
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
-				5C2B49A2C0D95BEA42197303 /* [CP] Embed Pods Frameworks */,
 				AF336ECA2164438A00B84B60 /* ShellScript */,
+				D6A7D50011191BEB905D7F99 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -196,7 +196,7 @@
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
-				0F07677CF348BE71C38E56B5 /* [CP] Embed Pods Frameworks */,
+				EB91EBAB0B4180F5943D6A04 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -271,26 +271,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0F07677CF348BE71C38E56B5 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SplitScreenScanner_Tests/Pods-SplitScreenScanner_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Sections/Sections.framework",
-				"${BUILT_PRODUCTS_DIR}/SplitScreenScanner/SplitScreenScanner.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sections.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SplitScreenScanner.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SplitScreenScanner_Tests/Pods-SplitScreenScanner_Tests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		5A254B5827612DFA736B8C83 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -309,26 +289,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5C2B49A2C0D95BEA42197303 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SplitScreenScanner_Example/Pods-SplitScreenScanner_Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Sections/Sections.framework",
-				"${BUILT_PRODUCTS_DIR}/SplitScreenScanner/SplitScreenScanner.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sections.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SplitScreenScanner.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SplitScreenScanner_Example/Pods-SplitScreenScanner_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		AF336ECA2164438A00B84B60 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -341,6 +301,30 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which ${PODS_ROOT}/SwiftLint/swiftlint >/dev/null; then\n    ${PODS_ROOT}/SwiftLint/swiftlint\nelse\n    echo \"SwiftLint does not exist\"\n    exit 1\nfi\n";
+		};
+		D6A7D50011191BEB905D7F99 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SplitScreenScanner_Example/Pods-SplitScreenScanner_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Sections/Sections.framework",
+				"${BUILT_PRODUCTS_DIR}/SplitScreenScanner/SplitScreenScanner.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sections.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SplitScreenScanner.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SplitScreenScanner_Example/Pods-SplitScreenScanner_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		DA9D53D965B2C76521D4E1F1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -358,6 +342,30 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EB91EBAB0B4180F5943D6A04 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SplitScreenScanner_Tests/Pods-SplitScreenScanner_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Sections/Sections.framework",
+				"${BUILT_PRODUCTS_DIR}/SplitScreenScanner/SplitScreenScanner.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sections.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SplitScreenScanner.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SplitScreenScanner_Tests/Pods-SplitScreenScanner_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/Tests/ScanHistoryViewModelTests.swift
+++ b/Example/Tests/ScanHistoryViewModelTests.swift
@@ -107,6 +107,24 @@ class ScanHistoryViewModelTests: XCTestCase {
         XCTAssertTrue(reloadedSectionHeader)
     }
 
+    func testPendingScan() {
+        setUpVM(scans: [], isScanningSessionExpirable: true)
+
+        var rowReloadedIndexPath: IndexPath?
+        viewModel.reloadRowObserver = { indexPath in
+            rowReloadedIndexPath = indexPath
+        }
+
+        var reloadedSectionHeader = false
+        viewModel.reloadSectionHeaderObserver = { _ in
+            reloadedSectionHeader = true
+        }
+
+        viewModel.didScan(barcode: "0000000001", with: .pending)
+        XCTAssertNil(rowReloadedIndexPath)
+        XCTAssertFalse(reloadedSectionHeader)
+    }
+
     func testCreateExpireSessionTimer() {
         setUpVM(scans: [], isScanningSessionExpirable: true)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ class StartScanningViewController: UIViewController {
             print(error)
         }
     }
+
+    // A `SplitScannerCoordinatorDelegate` can return a `pending` result from its `didScanBarcode` method. This is useful when an asynchronous task needs to be performed to determine if the scan was successful. Pending scans will not be displayed in the scan history.
+    //
+    // While the task is ongoing, it is recommended to block the scanner with `blockScanner`. When the task is completed, unblock the scanner with `unblockScanner` and manually add the appropriate `success`, `warning`, or `error` result to the scan history by calling `addScanResult`.
+    func addScanResult(_ scanResult: ScanResult, barcode: String) {
+        splitScannerCoordinator.addScanResult(scanResult, barcode: barcode)
+    }
 }
 
 // MARK: - SplitScannerCoordinatorDelegate

--- a/SplitScreenScanner.podspec
+++ b/SplitScreenScanner.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SplitScreenScanner'
-  s.version          = '6.1.0'
+  s.version          = '7.0.0'
   s.summary          = 'Swift library for scanning barcodes with half the screen devoted to scan history'
 
 # This description is used to generate tags and improve search results.

--- a/SplitScreenScanner/Classes/ScanHistory.swift
+++ b/SplitScreenScanner/Classes/ScanHistory.swift
@@ -11,6 +11,7 @@ public enum ScanResult: Equatable {
     case success(description: String?)
     case warning(description: String)
     case error(description: String)
+    case pending
 }
 
 struct ScanHistory {

--- a/SplitScreenScanner/Classes/ScanHistoryCell.swift
+++ b/SplitScreenScanner/Classes/ScanHistoryCell.swift
@@ -26,6 +26,9 @@ class ScanHistoryCell: UITableViewCell, IdentifierViewCell {
         case .error(let description):
             iconImageView.image = ScannerStyleKit.imageOfExclamationTriangleSymbol(imageSize: imageSize, isError: true)
             descriptionLabel.text = description
+        case .pending:
+            iconImageView.image = nil
+            descriptionLabel.text = nil
         }
     }
 }

--- a/SplitScreenScanner/Classes/ScanHistoryViewModel.swift
+++ b/SplitScreenScanner/Classes/ScanHistoryViewModel.swift
@@ -77,13 +77,25 @@ class ScanHistoryViewModel {
 
 // MARK: - Public Methods
 extension ScanHistoryViewModel {
-    func didScan(barcode: String, with result: ScanResult) {
-        let scan = ScanHistory(barcode: barcode, scanResult: result)
-        insert(newScan: scan)
-        hapticFeedbackManager?.didScan(with: result)
-        scanHistoryDataSource.playBarcodeScanSound(for: result)
+    func didScan(barcode: String, with result: ScanResult, hapticFeedbackEnabled: Bool = true, soundEnabled: Bool = true) {
         resetExpireSessionTimer()
-        reloadSectionHeaderObserver?(0)
+
+        if hapticFeedbackEnabled {
+            hapticFeedbackManager?.didScan(with: result)
+        }
+
+        if soundEnabled {
+            scanHistoryDataSource.playBarcodeScanSound(for: result)
+        }
+
+        switch result {
+        case .success, .error, .warning:
+            let scan = ScanHistory(barcode: barcode, scanResult: result)
+            insert(newScan: scan)
+            reloadSectionHeaderObserver?(0)
+        case .pending:
+            break
+        }
     }
 
     func createExpireSessionTimer() {

--- a/SplitScreenScanner/Classes/ScanToContinueViewModel.swift
+++ b/SplitScreenScanner/Classes/ScanToContinueViewModel.swift
@@ -81,6 +81,8 @@ extension ScanToContinueViewModel {
             delegate?.scanToContinueViewModel(self, didScanStartingBarcode: barcode)
         case let .warning(description), let .error(description):
             displayScanWarning(description)
+        case .pending:
+            break
         }
     }
 

--- a/SplitScreenScanner/Classes/ScannerHapticFeedbackManager.swift
+++ b/SplitScreenScanner/Classes/ScannerHapticFeedbackManager.swift
@@ -21,7 +21,7 @@ extension ScannerHapticFeedbackManager {
     func didScan(with result: ScanResult) {
         DispatchQueue.main.async { [weak self] in
             switch result {
-            case .success:
+            case .success, .pending:
                 self?.feedbackGenerator.notificationOccurred(.success)
             case .warning:
                 self?.feedbackGenerator.notificationOccurred(.warning)

--- a/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
+++ b/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
@@ -113,6 +113,10 @@ extension SplitScannerCoordinator {
     public func resetLastScannedBarcode() {
         barcodeScannerViewModel?.resetLastScannedBarcode()
     }
+
+    public func addScanResult(_ scanResult: ScanResult, barcode: String, hapticFeedbackEnabled: Bool = false, soundEnabled: Bool = false) {
+        scanHistoryViewModel?.didScan(barcode: barcode, with: scanResult, hapticFeedbackEnabled: hapticFeedbackEnabled, soundEnabled: soundEnabled)
+    }
 }
 
 // MARK: - Private Methods


### PR DESCRIPTION
This commit adds a new `pending` option to `ScanResult`. This is useful for cases where a network request needs to be performed before it can be determined whether a result should be a
`success`, `warning`, or `error`. A `pending` result is not added to the table. A new function is also introduced to allow manually adding a result to the table, so that when the network task is complete, the appropriate result can be displayed.