### PR TITLE
Add Ability to Manually Pop the Root Coordinator

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Sections (0.8.0)
-  - SplitScreenScanner (7.0.2):
+  - SplitScreenScanner (7.1.0):
     - Sections
-  - SwiftLint (0.33.1)
+  - SwiftLint (0.34.0)
 
 DEPENDENCIES:
   - SplitScreenScanner (from `../`)
@@ -19,8 +19,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Sections: efc268a207d0e7afba82d2a0efd6cdf61872b5d4
-  SplitScreenScanner: 9965d9eb926f6e1ea31043079e389c153f8ea0f6
-  SwiftLint: 9fc1143bbacec37f94994a7d0d2a85b2154b6294
+  SplitScreenScanner: fd4a8d39f3c1a9eb0e98d5a84f1026b7a4c5cc23
+  SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
 
 PODFILE CHECKSUM: 662fda703b72b77c2ece8658c02a5b890176b006
 

--- a/SplitScreenScanner.podspec
+++ b/SplitScreenScanner.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SplitScreenScanner'
-  s.version          = '7.0.2'
+  s.version          = '7.1.0'
   s.summary          = 'Swift library for scanning barcodes with half the screen devoted to scan history'
 
 # This description is used to generate tags and improve search results.

--- a/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
+++ b/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
@@ -118,6 +118,10 @@ extension SplitScannerCoordinator {
         scanHistoryViewModel?.didScan(barcode: barcode, with: scanResult, hapticFeedbackEnabled: hapticFeedbackEnabled, soundEnabled: soundEnabled)
         dismissIfNecessary(for: scanResult)
     }
+
+    public func popCoordinators() {
+        rootCoordinator?.popCoordinator(self)
+    }
 }
 
 // MARK: - Private Methods


### PR DESCRIPTION
There are instances in which it is convenient to be able to manually dismiss the SplitScannerCoordinator. However, currently, dismissing the coordinator from its presenting controller causes a retain cycle, since the SplitScannerCoordinator is never popped from its root coordinator. This allows for popping the coordinator from outside of itself, which subsequently
allows for safe dismissal from the presenting controller.
