### PR TITLE
Bump to 9.0.0 - Allow Disabling the Dismiss Button

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Sections (0.8.0)
-  - SplitScreenScanner (8.1.0):
+  - SplitScreenScanner (9.0.0):
     - Sections
   - SwiftLint (0.34.0)
 
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Sections: efc268a207d0e7afba82d2a0efd6cdf61872b5d4
-  SplitScreenScanner: acf69a6e230161d23dab9d50f1d2fd57797a6db2
+  SplitScreenScanner: 841005570bfad76fb89f6a48890a39404aff2e10
   SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
 
 PODFILE CHECKSUM: 662fda703b72b77c2ece8658c02a5b890176b006

--- a/Example/SplitScreenScanner/StartScanningViewController.swift
+++ b/Example/SplitScreenScanner/StartScanningViewController.swift
@@ -44,7 +44,7 @@ extension StartScanningViewController: SplitScannerCoordinatorDelegate {
         }
     }
 
-    func didPressDismissButton(_ splitScannerCoordinator: SplitScannerCoordinator) {
+    func didTapDismissButton(_ splitScannerCoordinator: SplitScannerCoordinator) {
         splitScannerCoordinator.popCoordinators()
         dismiss(animated: true)
     }

--- a/Example/Tests/SplitScannerViewModelTests.swift
+++ b/Example/Tests/SplitScannerViewModelTests.swift
@@ -15,9 +15,9 @@ class SplitScannerViewModelTests: XCTestCase {
     private var viewModel: SplitScannerViewModel!
 
     private final class DelegateSink: SplitScannerViewModelDelegate {
-        var dismissButtonPressed = false
-        func didPressDismissButton(_ splitScreenScannerViewModel: SplitScannerViewModel) {
-            dismissButtonPressed = true
+        var tappedDismissButton = false
+        func didTapDismissButton(_ splitScreenScannerViewModel: SplitScannerViewModel) {
+            tappedDismissButton = true
         }
     }
 
@@ -57,11 +57,19 @@ class SplitScannerViewModelTests: XCTestCase {
         XCTAssertFalse(deviceProvider.isTorchOn)
     }
 
-    func testDismissButtonPressed() {
-        XCTAssertFalse(sink.dismissButtonPressed)
+    func testTappedDismissButtonWhenDismissTitleNotNil() {
+        XCTAssertFalse(sink.tappedDismissButton)
+        viewModel.tappedDismissButton()
+        XCTAssertTrue(sink.tappedDismissButton)
+    }
 
-        viewModel.dismissButtonPressed()
-        XCTAssertTrue(sink.dismissButtonPressed)
+    func testTappedDismissButtonWhenDismissTitleNil() {
+        viewModel = SplitScannerViewModel(deviceProvider: deviceProvider, scannerTitle: "Unit Test Title", scannerDismissTitle: nil)
+        viewModel.delegate = sink
+
+        XCTAssertFalse(sink.tappedDismissButton)
+        viewModel.tappedDismissButton()
+        XCTAssertFalse(sink.tappedDismissButton)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ extension StartScanningViewController: SplitScannerCoordinatorDelegate {
         }
     }
 
-    // Called when the dismiss button is pressed. Dismiss the scanner as appropriate.
-    func didPressDismissButton(_ splitScannerCoordinator: SplitScannerCoordinator) {
+    // Called when the dismiss button is tapped. Dismiss the scanner as appropriate.
+    // This will not be called if the `scannerDismissTitle` used to initialize the `SplitScannerCoordinator` is nil.
+    func didTapDismissButton(_ splitScannerCoordinator: SplitScannerCoordinator) {
         print("Closing SplitScreenScanner")
         splitScannerCoordinator.popCoordinators()
         dismiss(animated: true)

--- a/SplitScreenScanner.podspec
+++ b/SplitScreenScanner.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SplitScreenScanner'
-  s.version          = '8.1.0'
+  s.version          = '9.0.0'
   s.summary          = 'Swift library for scanning barcodes with half the screen devoted to scan history'
 
 # This description is used to generate tags and improve search results.

--- a/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
+++ b/SplitScreenScanner/Classes/SplitScannerCoordinator.swift
@@ -10,7 +10,7 @@ import AVFoundation
 
 public protocol SplitScannerCoordinatorDelegate: class {
     func didScanBarcode(_ splitScannerCoordinator: SplitScannerCoordinator, barcode: String) -> ScanResult
-    func didPressDismissButton(_ splitScannerCoordinator: SplitScannerCoordinator)
+    func didTapDismissButton(_ splitScannerCoordinator: SplitScannerCoordinator)
 
     // Optional
     func shouldDismiss(after scanResult: ScanResult) -> Bool
@@ -54,7 +54,7 @@ public class SplitScannerCoordinator: RootCoordinator, Coordinator {
     weak var rootCoordinator: RootCoordinator?
     public weak var delegate: SplitScannerCoordinatorDelegate?
 
-    public init(scannerTitle: String, scannerDismissTitle: String, scanHistoryDataSource: ScanHistoryDataSource, scanToContinueDataSource: ScanToContinueDataSource?) throws {
+    public init(scannerTitle: String, scannerDismissTitle: String?, scanHistoryDataSource: ScanHistoryDataSource, scanToContinueDataSource: ScanToContinueDataSource?) throws {
         guard let videoDevice = AVCaptureDevice.default(for: .video) else {
             throw ContinuousBarcodeScannerError.noCamera
         }
@@ -207,8 +207,8 @@ private extension SplitScannerCoordinator {
 
 // MARK: - SplitScannerViewModelDelegate
 extension SplitScannerCoordinator: SplitScannerViewModelDelegate {
-    func didPressDismissButton(_ splitScreenScannerViewModel: SplitScannerViewModel) {
-        delegate?.didPressDismissButton(self)
+    func didTapDismissButton(_ splitScreenScannerViewModel: SplitScannerViewModel) {
+        delegate?.didTapDismissButton(self)
     }
 }
 

--- a/SplitScreenScanner/Classes/SplitScannerViewController.swift
+++ b/SplitScreenScanner/Classes/SplitScannerViewController.swift
@@ -24,7 +24,7 @@ class SplitScannerViewController: UIViewController {
         }
 
         torchButton.addTarget(self, action: #selector(torchButtonPressed), for: .touchUpInside)
-        dismissButton.addTarget(self, action: #selector(dismissButtonPressed), for: .touchUpInside)
+        dismissButton.addTarget(self, action: #selector(tappedDismissButton), for: .touchUpInside)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -59,7 +59,7 @@ private extension SplitScannerViewController {
         viewModel.toggleTorch()
     }
 
-    @objc func dismissButtonPressed() {
-        viewModel.dismissButtonPressed()
+    @objc func tappedDismissButton() {
+        viewModel.tappedDismissButton()
     }
 }

--- a/SplitScreenScanner/Classes/SplitScannerViewModel.swift
+++ b/SplitScreenScanner/Classes/SplitScannerViewModel.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 protocol SplitScannerViewModelDelegate: class {
-    func didPressDismissButton(_ splitScreenScannerViewModel: SplitScannerViewModel)
+    func didTapDismissButton(_ splitScreenScannerViewModel: SplitScannerViewModel)
 }
 
 class SplitScannerViewModel {
     let scannerTitle: String
-    let scannerDismissTitle: String
+    let scannerDismissTitle: String?
     var deviceProvider: DeviceProviding
 
     weak var delegate: SplitScannerViewModelDelegate?
@@ -25,7 +25,7 @@ class SplitScannerViewModel {
     }
     var scannerState: ScannerState
 
-    init(deviceProvider: DeviceProviding, scannerTitle: String, scannerDismissTitle: String) {
+    init(deviceProvider: DeviceProviding, scannerTitle: String, scannerDismissTitle: String?) {
         self.deviceProvider = deviceProvider
         self.scannerState = .notStarted
         self.scannerTitle = scannerTitle
@@ -57,8 +57,9 @@ class SplitScannerViewModel {
 
 // MARK: - Public Methods
 extension SplitScannerViewModel {
-    func dismissButtonPressed() {
-        delegate?.didPressDismissButton(self)
+    func tappedDismissButton() {
+        guard scannerDismissTitle != nil else { return }
+        delegate?.didTapDismissButton(self)
     }
 
     func toggleTorch() {


### PR DESCRIPTION
There are cases where we do not want to allow the user to manually dismiss the scanner. Now, the `scannerDismissTitle` can be set to nil, which will disable the dismiss button.
