### PR TITLE
Camera settings

### DIFF
--- a/SplitScreenScanner/Classes/BarcodeScannerViewController.swift
+++ b/SplitScreenScanner/Classes/BarcodeScannerViewController.swift
@@ -52,9 +52,8 @@ class BarcodeScannerViewController: UIViewController {
         scannerOverlayView.alpha = 0
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         viewModel.startRunningBarcodeScanner()
     }
 

--- a/SplitScreenScanner/Classes/ContinuousBarcodeScanner.swift
+++ b/SplitScreenScanner/Classes/ContinuousBarcodeScanner.swift
@@ -67,16 +67,18 @@ final class ContinuousBarcodeScanner {
 
         do {
             try videoDevice.lockForConfiguration()
+            videoDevice.focusMode = .continuousAutoFocus
+            videoDevice.exposureMode = .continuousAutoExposure
+            videoDevice.whiteBalanceMode = .continuousAutoWhiteBalance
+
+            if videoDevice.isAutoFocusRangeRestrictionSupported {
+                videoDevice.autoFocusRangeRestriction = .near
+            }
+
+            videoDevice.unlockForConfiguration()
         } catch {
             throw ContinuousBarcodeScannerError.couldNotInitCamera
         }
-        videoDevice.focusMode = .continuousAutoFocus
-        videoDevice.exposureMode = .continuousAutoExposure
-        videoDevice.whiteBalanceMode = .continuousAutoWhiteBalance
-        if videoDevice.isAutoFocusRangeRestrictionSupported {
-            videoDevice.autoFocusRangeRestriction = .near
-        }
-        videoDevice.unlockForConfiguration()
 
         captureSession = AVCaptureSession()
         captureSession.sessionPreset = .high

--- a/SplitScreenScanner/Classes/ContinuousBarcodeScanner.swift
+++ b/SplitScreenScanner/Classes/ContinuousBarcodeScanner.swift
@@ -75,13 +75,17 @@ final class ContinuousBarcodeScanner {
                 videoDevice.autoFocusRangeRestriction = .near
             }
 
+            if videoDevice.isSmoothAutoFocusSupported {
+                videoDevice.isSmoothAutoFocusEnabled = false
+            }
+
             videoDevice.unlockForConfiguration()
         } catch {
             throw ContinuousBarcodeScannerError.couldNotInitCamera
         }
 
         captureSession = AVCaptureSession()
-        captureSession.sessionPreset = .high
+        captureSession.sessionPreset = .photo
 
         guard let videoInput = try? AVCaptureDeviceInput(device: videoDevice) else {
             throw ContinuousBarcodeScannerError.couldNotInitCamera


### PR DESCRIPTION
## Feature Description
Fixes bug in camera configuration that would potentially crash if the app failed to lock the camera for configuration.

Change device settings to disable smooth auto-focus and set the preset to .photo for better metadata extraction.

Start the scanner on viewWillAppear so that the scan screen appears without delay.