### PR TITLE
9.1.1 - Fix Potential Internal Inconsistency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: 11.0.0
+      xcode: 12.5.1
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: /Users/distiller/project/Example/fastlane/test_output

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Sections (0.8.0)
-  - SplitScreenScanner (9.0.2):
+  - SplitScreenScanner (9.1.0):
     - Sections
   - SwiftLint (0.34.0)
 
@@ -20,9 +20,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Sections: efc268a207d0e7afba82d2a0efd6cdf61872b5d4
-  SplitScreenScanner: 48ddf2c2db8bb133a0b7991e29fd9e3fb0546c05
+  SplitScreenScanner: ade060b2b8f724c66488d510cbe0791db930c520
   SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
 
 PODFILE CHECKSUM: e3b551128f802187ddddf037b42e5f79c866fb2a
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.8.4

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Sections (0.8.0)
-  - SplitScreenScanner (9.1.0):
+  - SplitScreenScanner (9.1.1):
     - Sections
   - SwiftLint (0.34.0)
 
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Sections: efc268a207d0e7afba82d2a0efd6cdf61872b5d4
-  SplitScreenScanner: ade060b2b8f724c66488d510cbe0791db930c520
+  SplitScreenScanner: a4e8c1c708f5434b3d4374218463ddd7d81c7774
   SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
 
 PODFILE CHECKSUM: e3b551128f802187ddddf037b42e5f79c866fb2a

--- a/SplitScreenScanner.podspec
+++ b/SplitScreenScanner.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SplitScreenScanner'
-  s.version          = '9.1.0'
+  s.version          = '9.1.1'
   s.summary          = 'Swift library for scanning barcodes with half the screen devoted to scan history'
 
 # This description is used to generate tags and improve search results.

--- a/SplitScreenScanner/Classes/ScanHistoryTableViewController.swift
+++ b/SplitScreenScanner/Classes/ScanHistoryTableViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 class ScanHistoryTableViewController: UITableViewController {
     var viewModel: ScanHistoryViewModel!
 
+    private var pendingInsertions: [IndexPath] = []
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -20,8 +22,13 @@ class ScanHistoryTableViewController: UITableViewController {
         }
 
         viewModel.insertRowObserver = { [weak self] indexPath in
+            self?.pendingInsertions.insert(indexPath, at: 0)
             DispatchQueue.main.async {
-                self?.tableView.insertRows(at: [indexPath], with: .left)
+                guard let pendingInsertions = self?.pendingInsertions, !pendingInsertions.isEmpty else {
+                    return
+                }
+                self?.tableView.insertRows(at: pendingInsertions, with: .left)
+                self?.pendingInsertions = []
             }
         }
 


### PR DESCRIPTION
- Fixes a potential Internal Inconsistency Exception within the Scan
  History Controller
- Since the data source is getting updated potentially on a different
  thread than the controller's insert call, it is possible that the data
  source and the pending update get out of sync ahead of the update

## Feature Description
Fixes a rare crash in the Scan History Controller where the backing datasource was out of sync when calling `insertRows` on the table view

## What To Test?
Tough to test because the crash was so infrequent. Confirm that the Scan History controller is correctly showing scans and that rapid scans don't cause any crashes
