### PR TITLE
Fix Inconsistency Exception

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Sections (0.8.0)
-  - SplitScreenScanner (9.1.1):
+  - SplitScreenScanner (9.1.2):
     - Sections
   - SwiftLint (0.34.0)
 
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Sections: efc268a207d0e7afba82d2a0efd6cdf61872b5d4
-  SplitScreenScanner: a4e8c1c708f5434b3d4374218463ddd7d81c7774
+  SplitScreenScanner: 49c6e8302807ab1db9361bb682ea5b4335b9b921
   SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
 
 PODFILE CHECKSUM: e3b551128f802187ddddf037b42e5f79c866fb2a

--- a/Example/Tests/ScanHistoryViewModelTests.swift
+++ b/Example/Tests/ScanHistoryViewModelTests.swift
@@ -71,8 +71,13 @@ class ScanHistoryViewModelTests: XCTestCase {
         setUpVM(scans: [], isScanningSessionExpirable: true)
 
         var rowReloadedIndexPath: IndexPath?
-        viewModel.reloadRowObserver = { indexPath in
-            rowReloadedIndexPath = indexPath
+        viewModel.rowUpdateObserver = { rowUpdate in
+            switch rowUpdate {
+            case .reloadRow(let indexPath):
+                rowReloadedIndexPath = indexPath
+            case .insertRow(let indexPath):
+                XCTFail("Expected Reload but got Insert for IndexPath: \(String(describing: indexPath))")
+            }
         }
 
         var reloadedSectionHeader = false
@@ -93,8 +98,13 @@ class ScanHistoryViewModelTests: XCTestCase {
         setUpVM(scans: scans, isScanningSessionExpirable: true)
 
         var rowInsertedIndexPath: IndexPath?
-        viewModel.insertRowObserver = { indexPath in
-            rowInsertedIndexPath = indexPath
+        viewModel.rowUpdateObserver = { rowUpdate in
+            switch rowUpdate {
+            case .insertRow(let indexPath):
+                rowInsertedIndexPath = indexPath
+            case .reloadRow(let indexPath):
+                XCTFail("Expected Insert but got Reload for IndexPath: \(String(describing: indexPath))")
+            }
         }
 
         var reloadedSectionHeader = false
@@ -111,8 +121,13 @@ class ScanHistoryViewModelTests: XCTestCase {
         setUpVM(scans: [], isScanningSessionExpirable: true)
 
         var rowReloadedIndexPath: IndexPath?
-        viewModel.reloadRowObserver = { indexPath in
-            rowReloadedIndexPath = indexPath
+        viewModel.rowUpdateObserver = { rowUpdate in
+            switch rowUpdate {
+            case .reloadRow(let indexPath):
+                rowReloadedIndexPath = indexPath
+            case .insertRow(let indexPath):
+                XCTFail("Expected Reload but got Insert for IndexPath: \(String(describing: indexPath))")
+            }
         }
 
         var reloadedSectionHeader = false
@@ -130,8 +145,13 @@ class ScanHistoryViewModelTests: XCTestCase {
         setUpVM(scans: [firstScan], isScanningSessionExpirable: true)
 
         var rowReloadedIndexPath: IndexPath?
-        viewModel.reloadRowObserver = { indexPath in
-            rowReloadedIndexPath = indexPath
+        viewModel.rowUpdateObserver = { rowUpdate in
+            switch rowUpdate {
+            case .reloadRow(let indexPath):
+                rowReloadedIndexPath = indexPath
+            case .insertRow(let indexPath):
+                XCTFail("Expected Reload but got Insert for IndexPath: \(String(describing: indexPath))")
+            }
         }
 
         viewModel.cancelScannedBarcode(firstScan.barcode)
@@ -148,8 +168,13 @@ class ScanHistoryViewModelTests: XCTestCase {
         setUpVM(scans: scans, isScanningSessionExpirable: true)
 
         var rowDeletedIndexPath: IndexPath?
-        viewModel.reloadRowObserver = { indexPath in
-            rowDeletedIndexPath = indexPath
+        viewModel.rowUpdateObserver = { rowUpdate in
+            switch rowUpdate {
+            case .reloadRow(let indexPath):
+                rowDeletedIndexPath = indexPath
+            case .insertRow(let indexPath):
+                XCTFail("Expected Reload but got Insert for IndexPath: \(String(describing: indexPath))")
+            }
         }
 
         viewModel.cancelScannedBarcode(firstScan.barcode)

--- a/SplitScreenScanner.podspec
+++ b/SplitScreenScanner.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SplitScreenScanner'
-  s.version          = '9.1.1'
+  s.version          = '9.1.2'
   s.summary          = 'Swift library for scanning barcodes with half the screen devoted to scan history'
 
 # This description is used to generate tags and improve search results.

--- a/SplitScreenScanner/Classes/ScanHistoryViewModel.swift
+++ b/SplitScreenScanner/Classes/ScanHistoryViewModel.swift
@@ -51,9 +51,12 @@ class ScanHistoryViewModel {
 
     // MARK: - Bindings, Observers, Getters
 
-    var reloadRowObserver: ((IndexPath) -> Void)?
+    enum RowUpdate {
+        case insertRow(IndexPath)
+        case reloadRow(IndexPath)
+    }
 
-    var insertRowObserver: ((IndexPath) -> Void)?
+    var rowUpdateObserver: ((RowUpdate) -> Void)?
 
     var reloadSectionHeaderObserver: ((_ sectionIndex: Int) -> Void)?
 
@@ -144,10 +147,10 @@ private extension ScanHistoryViewModel {
         // replace nothingScannedRow with historyRow if this is the first scan
         if scans.count == 1 {
             sections[firstRowIndexPath.section].rows[firstRowIndexPath.row] = historyRow
-            reloadRowObserver?(firstRowIndexPath)
+            rowUpdateObserver?(.reloadRow(firstRowIndexPath))
         } else {
             sections[firstRowIndexPath.section].rows.insert(historyRow, at: firstRowIndexPath.row)
-            insertRowObserver?(firstRowIndexPath)
+            rowUpdateObserver?(.insertRow(firstRowIndexPath))
         }
     }
 
@@ -167,6 +170,6 @@ private extension ScanHistoryViewModel {
 
         let indexPath = IndexPath(row: index, section: 0)
         sections[indexPath.section].rows[indexPath.row] = .historyRow(barcode: newScan.barcode, scanResult: newScan.scanResult)
-        reloadRowObserver?(indexPath)
+        rowUpdateObserver?(.reloadRow(indexPath))
     }
 }


### PR DESCRIPTION
## Bug Description
- If a user cancelled a scan and then immediately scanned another
  barcode, it was possible for the datasource and the table view to get
  out of sync
- Refactors the reload / insert observers to use a shared model and
  batch updates to the table view to ensure we stay in sync

## What To Test?
Tested using a modified version of the example app that canceled a scan immediately before adding a new one. Before the change it was consistently crashing with the Internal Inconsistency exception. Now it works as expected
